### PR TITLE
5.8 new fix for raty stars on heroku

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -1,10 +1,10 @@
 $(document).on('turbolinks:load', function(){
-    $('.rating').raty({path: '/assets/images'});
+    $('.rating').raty({path: '/assets'});
 });
 
 $(document).on('turbolinks:load', function(){
-  $('rating').raty({path: '/assets/images', scoreName: 'comment[rating]'});
-  $('.rated').raty({path: '/assets/images',
+  $('rating').raty({path: '/assets', scoreName: 'comment[rating]'});
+  $('.rated').raty({path: '/assets',
     readOnly: true,
     score: function() {
       return $(this).attr('data-score');

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
changed path to star images back to /assets
changed to config.assets.compile = true